### PR TITLE
fix: plurality of item counts for objects with 1 item

### DIFF
--- a/core/src/section/CountInfo.tsx
+++ b/core/src/section/CountInfo.tsx
@@ -33,7 +33,7 @@ export const CountInfoComp = <K extends TagType, T extends object>(
 
   const len = Object.keys(value).length;
   if (!reset.children) {
-    reset.children = `${len} items`;
+    reset.children = `${len} item${len === 1 ? '' : 's'}`;
   }
 
   const elmProps = { ...reset, ...other };


### PR DESCRIPTION
Previously collections with 1 item were listed as having "1 items", however it should read "1 item". Fixes #39 

Before
![Screenshot 2024-03-14 at 2 38 45 PM](https://github.com/uiwjs/react-json-view/assets/24704789/44f50618-82dc-46a5-9d39-bd5e6b690ba3)


After
<img width="219" alt="Screenshot 2024-03-14 at 2 38 21 PM" src="https://github.com/uiwjs/react-json-view/assets/24704789/1a04a028-3bfb-461d-99b6-3b33e6faa072">
