### PR TITLE
fix: Do not render ellipses when the number of items is 0

### DIFF
--- a/core/src/section/Ellipsis.tsx
+++ b/core/src/section/Ellipsis.tsx
@@ -23,7 +23,8 @@ export const EllipsisComp = <T extends object>({ isExpanded, value, keyName }: E
   const child =
     render && typeof render === 'function' && render({ ...reset, 'data-expanded': isExpanded }, { value, keyName });
   if (child) return child;
-  if (!isExpanded) return null;
+
+  if (!isExpanded || (typeof value === 'object' && Object.keys(value).length == 0)) return null;
   return <Elm {...reset} />;
 };
 


### PR DESCRIPTION


```
import JsonView from '@uiw/react-json-view';

const example = [
  {
    "a":[],
    "b":{},
    "c":['c1','c2'],
    "d":{d1:1,d2:2}
  },
]

export default function App() {
  return (
    <JsonView 
      value={example} 
      collapsed={2}
    >
    </JsonView>
  );
}

```

Ellipsis is being rendered on `a`and `b` even though their values are empty